### PR TITLE
Let the template id be the file name with all extensions stripped

### DIFF
--- a/lib/tpl.js
+++ b/lib/tpl.js
@@ -2,7 +2,7 @@ define({
     load: function (name, req, load, config) {
         req(['text!' + name], function (htmlString) {
             var fileName = name.split('/').pop(),
-                templateId = fileName.replace(/\.[^\.]*$/, ''), // Strip extension
+                templateId = fileName.replace(/\..*$/, ''), // Strip extension
                 existingScriptElement = document.getElementById(templateId);
 
             if (existingScriptElement) {
@@ -17,7 +17,7 @@ define({
                     div.innerHTML = htmlString;
                     var nestedScriptElements = div.getElementsByTagName('script');
                     while (nestedScriptElements.length > 0) {
-                        nestedScriptElement = nestedScriptElements[0];
+                        var nestedScriptElement = nestedScriptElements[0];
                         document.body.appendChild(nestedScriptElement);
                     }
                     htmlString = div.innerHTML;

--- a/test/tpl.js
+++ b/test/tpl.js
@@ -52,6 +52,11 @@ describe('tpl', function () {
         expect('Pure text', 'to be loaded as a template', '<html><head></head><body><script type="text/html" id="theTemplateName">Pure text</script></body></html>');
     });
 
+    it('should use the file name without any extension', function () {
+        templateName = 'theTemplateName.touch.html';
+        expect('Pure text', 'to be loaded as a template', '<html><head></head><body><script type="text/html" id="theTemplateName">Pure text</script></body></html>');
+    });
+
     it('should not overwrite an existing template of with the same id', function () {
         expect(function () {
             document.body.innerHTML = '<script type="text/html" id="theTemplateName">Existing pure text</script>';


### PR DESCRIPTION
We need the template id to only be the base of the file name in the Webmail in order to switch template for the touch version. The means webmail/components/contactList.ko and webmail/components/contactList.touch.ko would both be registered under the id: contactList
